### PR TITLE
Supply the server's root certificate in the http request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=maste
 name = "http_req"
 version = "0.8.1"
 dependencies = [
+ "log 0.4.11",
  "rustls 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
  "sgx_tstd 1.1.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ webpki_sgx  = { package = "webpki", git = "https://github.com/mesalock-linux/web
 webpki-roots_sgx = { package = "webpki-roots", git = "https://github.com/mesalock-linux/webpki-roots", branch = "mesalock_sgx", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
+log = { version = "0.4", default-features = false }
 unicase = { version = "2.6", optional = true }
 rustls = { version = "0.19", optional = true }
 webpki = { version = "0.21", optional = true }
@@ -42,6 +43,7 @@ sgx = [
     "webpki-roots_sgx"
 ]
 std = [
+    "log/std",
     "unicase",
     "rustls",
     "webpki",

--- a/src/request.rs
+++ b/src/request.rs
@@ -910,10 +910,10 @@ impl<'a> Request<'a> {
         }
     }
 
-    ///Sends HTTP request with the server root certificate to verify
-    ///
-    ///There are no other trusted root certificates. The connection will only be established
-    ///if the supplied certificate matches the server's root certificate.
+    ///Sends HTTP request.The connection will only be established if the supplied certificate
+    ///matches the server's root certificate.
+    ///Supply the content of the server's root certificate as a String. There are no predefined trusted
+    ///root certificates in the tls config.
     ///
     ///Creates `TcpStream` (and wraps it with `TlsStream` if needed). Writes request message
     ///to created stream. Returns response for this request. Writes response's body to `writer`.

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,6 +5,7 @@ use crate::{
     tls,
     uri::Uri,
 };
+use log::*;
 use std::{
     convert::TryFrom,
     fmt,
@@ -914,7 +915,7 @@ impl<'a> Request<'a> {
             };
             self.send_with_config(writer, Some(cnf))
         } else {
-            println!("Send with certificate, but not a https request!");
+            error!("Send with certificate, but not a https request!");
             Err(error::Error::Tls)
         }
     }
@@ -939,7 +940,7 @@ impl<'a> Request<'a> {
         if self.inner.uri.scheme() == "https" {
             let mut stream = config
                 .ok_or_else(|| {
-                    println!("No tls config defined for the https request!");
+                    error!("No tls config defined for the https request!");
                     error::Error::Tls
                 })?
                 .connect(host, stream)?;


### PR DESCRIPTION
- add a method to allow https connections only with the supply of the right server's root certificate
- add a config for tls Config with no root certificates